### PR TITLE
fix multiple %01 wildcards

### DIFF
--- a/cpe/comp/cpecomp2_3_uri.py
+++ b/cpe/comp/cpecomp2_3_uri.py
@@ -207,8 +207,8 @@ class CPEComponent2_3_URI(CPEComponent2_3):
                 # embedded is false, so must be preceded by %01
                 # embedded is true, so must be followed by %01
                 if (((idx == 0) or (idx == (len(s)-3))) or
-                   ((not embedded) and (s[idx - 3, idx - 1] == CPEComponent2_3_URI.WILDCARD_MULTI)) or
-                   (embedded and (len(s) >= idx + 6) and (s[idx + 3, idx + 5] == CPEComponent2_3_URI.PCE_ASTERISK))):
+                    ((not embedded) and (s[idx - 3:idx] == CPEComponent2_3_URI.WILDCARD_ONE)) or
+                    (embedded and (len(s) >= idx + 6) and (s[idx + 3:idx + 6] == CPEComponent2_3_URI.WILDCARD_ONE))):
 
                     # A percent-encoded question mark is found
                     # at the beginning or the end of the string,


### PR DESCRIPTION
multiple off-by-ones, wrong syntax and stale constants on two lines

fixes #7 but I think there should be some tests as well

This works now:

``` python
>>> CPE2_3_URI('cpe:/a:microsoft:internet_explorer:%01%018.%02:%02s%01%01%01').as_wfn()
'wfn:[part="a", vendor="microsoft", product="internet_explorer", version="??8\\.*", update="*s???"]'
```
