### PR TITLE
turn CPESet2_3.compare_wfns into a generator

### DIFF
--- a/cpe/cpeset2_3.py
+++ b/cpe/cpeset2_3.py
@@ -275,7 +275,7 @@ class CPESet2_3(CPESet):
     @classmethod
     def compare_wfns(cls, source, target):
         """
-        Compares two WFNs and returns a list of pairwise attribute-value
+        Compares two WFNs and returns a generator of pairwise attribute-value
         comparison results. It provides full access to the individual
         comparison results to enable use-case specific implementations
         of novel name-comparison algorithms.
@@ -284,12 +284,9 @@ class CPESet2_3(CPESet):
 
         :param CPE2_3_WFN source: first WFN CPE Name
         :param CPE2_3_WFN target: seconds WFN CPE Name
-        :returns: List of pairwise attribute comparison results
-        :rtype: int
+        :returns: generator of pairwise attribute comparison results
+        :rtype: generator
         """
-
-        # Create a new associative array table implemented as a dictionary
-        result = dict()
 
         # Compare results using the get() function in WFN
         for att in CPEComponent.CPE_COMP_KEYS_EXTENDED:
@@ -303,9 +300,7 @@ class CPESet2_3(CPESet):
                 # Not a logical value: del double quotes
                 value_tar = value_tar[1:-1]
 
-            result[att] = CPESet2_3._compare(value_src, value_tar)
-
-        return result
+            yield (att, CPESet2_3._compare(value_src, value_tar))
 
     @classmethod
     def cpe_disjoint(cls, source, target):
@@ -320,13 +315,9 @@ class CPESet2_3(CPESet):
         :rtype: boolean
         """
 
-        result_dict = CPESet2_3.compare_wfns(source, target)
-
         # If any pairwise comparison returned DISJOINT  then
         # the overall name relationship is DISJOINT
-        for att in CPEComponent.CPE_COMP_KEYS_EXTENDED:
-            result = result_dict[att]
-
+        for att, result in CPESet2_3.compare_wfns(source, target):
             isDisjoint = result == CPESet2_3.LOGICAL_VALUE_DISJOINT
             if isDisjoint:
                 return True
@@ -345,13 +336,9 @@ class CPESet2_3(CPESet):
         :rtype: boolean
         """
 
-        result_dict = CPESet2_3.compare_wfns(source, target)
-
         # If any pairwise comparison returned EQUAL then
         # the overall name relationship is EQUAL
-        for att in CPEComponent.CPE_COMP_KEYS_EXTENDED:
-            result = result_dict[att]
-
+        for att, result in CPESet2_3.compare_wfns(source, target):
             isEqual = result == CPESet2_3.LOGICAL_VALUE_EQUAL
             if not isEqual:
                 return False
@@ -370,13 +357,9 @@ class CPESet2_3(CPESet):
         :rtype: boolean
         """
 
-        result_dict = CPESet2_3.compare_wfns(source, target)
-
         # If any pairwise comparison returned something other than SUBSET
         # or EQUAL, then SUBSET is False.
-        for att in CPEComponent.CPE_COMP_KEYS_EXTENDED:
-            result = result_dict[att]
-
+        for att, result in CPESet2_3.compare_wfns(source, target):
             isSubset = result == CPESet2_3.LOGICAL_VALUE_SUBSET
             isEqual = result == CPESet2_3.LOGICAL_VALUE_EQUAL
             if (not isSubset) and (not isEqual):
@@ -396,13 +379,9 @@ class CPESet2_3(CPESet):
         :rtype: boolean
         """
 
-        result_dict = CPESet2_3.compare_wfns(source, target)
-
         # If any pairwise comparison returned something other than SUPERSET
         # or EQUAL, then SUPERSET is False.
-        for att in CPEComponent.CPE_COMP_KEYS_EXTENDED:
-            result = result_dict[att]
-
+        for att, result in CPESet2_3.compare_wfns(source, target):
             isSuperset = result == CPESet2_3.LOGICAL_VALUE_SUPERSET
             isEqual = result == CPESet2_3.LOGICAL_VALUE_EQUAL
             if (not isSuperset) and (not isEqual):


### PR DESCRIPTION
This way some comparisons can be short-circuited for faster matches...

I've extensively tested this with real-world data and get speed improvements by a factor of 6.

(Of course the worst-case complexity is identical to the list-based implementation, if every list only matches at the last item.)
