### PR TITLE
correctly transform not applicable values for edition

### DIFF
--- a/cpe/cpe.py
+++ b/cpe/cpe.py
@@ -463,7 +463,8 @@ class CPE(dict):
                isinstance(comp, CPEComponentAnyValue)):
 
                 value = ""
-
+            elif (isinstance(comp, CPEComponentNotApplicable)):
+                value = CPEComponent2_3_URI.VALUE_NA
             else:
                 # Component has some value; transform this original value
                 # in URI value


### PR DESCRIPTION
Hi!

```
>>> from cpe.cpe import CPE
>>> CPE('wfn:[part="a", vendor="TauPan", product="cpelib", version="1\\.0\\.5", update=NA, edition=NA]').as_uri_2_3()
```

Throws an exception AttributeError: 'CPEComponentNotApplicable' object has no attribute 'as_uri_2_3', which my patch fixes.
