### PR TITLE
Fixed problem when comparing with _compare_strings

### DIFF
--- a/cpe/cpeset2_3.py
+++ b/cpe/cpeset2_3.py
@@ -188,8 +188,9 @@ class CPESet2_3(CPESet):
 
                 break
 
-            escapes = target.count("\\", index + 1, len(target))
-            leftover = len(target) - index - escapes - len(source)
+            escapes = target.count("\\", index + 1)
+            source_escapes = source.count("\\", index + 1)
+            leftover = len(target) - index + source_escapes - escapes - len(source)
             if ((leftover > 0) and ((ends != -1) and (leftover > ends))):
                 continue
 
@@ -439,4 +440,4 @@ class CPESet2_3(CPESet):
 if __name__ == "__main__":
     import doctest
     doctest.testmod()
-    doctest.testfile("tests/testfile_cpeset2_3.txt")
+    doctest.testfile("../tests/testfile_cpeset2_3.txt")

--- a/tests/testfile_cpeset2_3.txt
+++ b/tests/testfile_cpeset2_3.txt
@@ -49,6 +49,14 @@ True
 >>> CPESet2_3._compare_strings("mac*", "mac") == CPESet2_3.LOGICAL_VALUE_SUPERSET
 True
 
+- TEST:
+>>> CPESet2_3._compare_strings("1\\.0\\.?", "1\\.0\\.12") == CPESet2_3.LOGICAL_VALUE_DISJOINT
+True
+
+- TEST:
+>>> CPESet2_3._compare_strings("1\\.0\\.1", "1\\.0\\.12") == CPESet2_3.LOGICAL_VALUE_DISJOINT
+True
+
 ----------------------------------
 Test for _is_string(cls, arg)
 ----------------------------------


### PR DESCRIPTION
When escapes aren't taken into account in source string, erratic behavior is encountered when comparing with **CPESet2_3._compare_strings**:

| source | target | outcome |
| ------- | ------- | ------ |
| "1\\.0\\.?" | "1\\.0\\.12" | is considered super set |
| "1\\.0\\.1" |"1\\.0\\.12" | is considered super set |
