### PR TITLE
Primitive implementation of NVD JSON configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ docs/_build/
 
 coverage.xml
 htmlcov
+
+.idea
+venv

--- a/cpe/cpelang2_3.py
+++ b/cpe/cpelang2_3.py
@@ -177,6 +177,8 @@ class CPELanguage2_3(CPELanguage):
 
         dom_impl = getDOMImplementation()
         xml_doc = dom_impl.createDocument('http://cpe.mitre.org/language/2.0', 'cpe:platform-specification', None)
+        # The XML prefix is not exported by minidom, therefore we add it as attribute so that it gets exported
+        xml_doc.documentElement.setAttribute('xmlns:cpe', 'http://cpe.mitre.org/language/2.0')
 
         platform = xml_doc.createElement('cpe:platform')
         xml_doc.documentElement.appendChild(platform)
@@ -189,10 +191,7 @@ class CPELanguage2_3(CPELanguage):
         for node in raw_json:
             root_logical_test.appendChild(cls._translate_json_child(xml_doc, node))
 
-        # Group all of them inside a big OR logical-test (todo even when there's only one?)
-        # TODO: find out why xml namespace is not being exported
-        return xml_doc.toxml().replace('<cpe:platform-specification>',
-                                       '<cpe:platform-specification xmlns:cpe="http://cpe.mitre.org/language/2.0">')
+        return xml_doc.toxml()
 
     @classmethod
     def _translate_json_child(cls, doc, child):

--- a/cpe/cpelang2_3.py
+++ b/cpe/cpelang2_3.py
@@ -29,6 +29,8 @@ feedback about it, please contact:
 - Alejandro Galindo García: galindo.garcia.alejandro@gmail.com
 - Roberto Abdelkader Martínez Pérez: robertomartinezp@gmail.com
 """
+import json
+from xml.dom.minidom import getDOMImplementation
 
 from .cpeset2_3 import CPESet2_3
 from .cpelang import CPELanguage
@@ -165,9 +167,59 @@ class CPELanguage2_3(CPELanguage):
         else:
             return CPE2_3_WFN(fs.as_wfn())
 
+    @classmethod
+    def _translate_json(cls, expression, isFile):
+        if isFile:
+            with open(expression) as f:
+                raw_json = json.load(f)
+        else:
+            raw_json = json.loads(expression)
+
+        dom_impl = getDOMImplementation()
+        xml_doc = dom_impl.createDocument('http://cpe.mitre.org/language/2.0', 'cpe:platform-specification', None)
+
+        platform = xml_doc.createElement('cpe:platform')
+        xml_doc.documentElement.appendChild(platform)
+
+        root_logical_test = xml_doc.createElement('cpe:logical-test')
+        root_logical_test.setAttribute('operator', 'OR')
+        root_logical_test.setAttribute('negate', 'FALSE')
+        platform.appendChild(root_logical_test)
+
+        for node in raw_json:
+            root_logical_test.appendChild(cls._translate_json_child(xml_doc, node))
+
+        # Group all of them inside a big OR logical-test (todo even when there's only one?)
+        # TODO: find out why xml namespace is not being exported
+        return xml_doc.toxml().replace('<cpe:platform-specification>',
+                                       '<cpe:platform-specification xmlns:cpe="http://cpe.mitre.org/language/2.0">')
+
+    @classmethod
+    def _translate_json_child(cls, doc, child):
+        element = doc.createElement('cpe:logical-test')
+        element.setAttribute('operator', child['operator'])
+        element.setAttribute('negate', 'FALSE')  # TODO ?
+
+        for children in child['children']:
+            element.appendChild(cls._translate_json_child(doc, children))
+
+        for cpe_match in child['cpe_match']:
+            cpe_element = doc.createElement('cpe:fact-ref')
+            cpe_element.setAttribute('name', cpe_match['cpe23Uri'])
+            element.appendChild(cpe_element)
+
+        return element
+
     ####################
     #  OBJECT METHODS  #
     ####################
+
+    def __init__(self, expression, isFile=False, isJSON=False):
+        if isJSON:
+            expression = self._translate_json(expression, isFile)
+            isFile = False
+
+        super().__init__(expression, isFile)
 
     def language_match(self, cpeset, cpel_dom=None):
         """

--- a/tests/expression2_3.json
+++ b/tests/expression2_3.json
@@ -1,0 +1,35 @@
+[
+  {
+    "operator": "AND",
+    "children": [
+      {
+        "operator": "OR",
+        "children": [],
+        "cpe_match": [
+          {
+            "vulnerable": true,
+            "cpe23Uri": "cpe:2.3:o:sun:solaris:5.8:*:*:*:*:*:*:*",
+            "cpe_name": []
+          },
+          {
+            "vulnerable": true,
+            "cpe23Uri": "cpe:2.3:o:sun:solaris:5.9:*:*:*:*:*:*:*",
+            "cpe_name": []
+          }
+        ]
+      },
+      {
+        "operator": "OR",
+        "children": [],
+        "cpe_match": [
+          {
+            "vulnerable": true,
+            "cpe23Uri": "cpe:2.3:a:bea:weblogic:8.1:*:*:*:*:*:*:*",
+            "cpe_name": []
+          }
+        ]
+      }
+    ],
+    "cpe_match": []
+  }
+]

--- a/tests/testfile_cpelang2_3.txt
+++ b/tests/testfile_cpelang2_3.txt
@@ -37,7 +37,7 @@ False
 True
 
 
-- TEST: matching
+- TEST: not matching
 >>> path = "expression2_3.xml"
 
 >>> c1 = CPE2_3_FS('cpe:2.3:o:sun:solaris:5.9:*:*:*:*:*:*:*')
@@ -51,6 +51,38 @@ True
 >>> l = CPELanguage2_3(path, isFile)
 >>> l.language_match(s)
 False
+
+- TEST: not matching with JSON file
+>>> path = "expression2_3.json"
+
+>>> c1 = CPE2_3_FS('cpe:2.3:o:sun:solaris:5.9:*:*:*:*:*:*:*')
+>>> c2 = CPE2_3_FS('cpe:2.3:a:bea:weblogic:8.*:*:*:*:*:*:*:*')
+
+>>> s = CPESet2_3()
+>>> s.append(c1)
+>>> s.append(c2)
+
+>>> isFile = True
+>>> isJSON = True
+>>> l = CPELanguage2_3(path, isFile, isJSON)
+>>> l.language_match(s)
+False
+
+- TEST: matching with JSON file
+>>> path = "expression2_3.json"
+
+>>> c1 = CPE2_3_FS('cpe:2.3:o:sun:solaris:5.9:*:*:*:*:*:*:*')
+>>> c2 = CPE2_3_FS('cpe:2.3:a:bea:weblogic:8.1:*:*:*:*:*:*:*')
+
+>>> s = CPESet2_3()
+>>> s.append(c1)
+>>> s.append(c2)
+
+>>> isFile = True
+>>> isJSON = True
+>>> l = CPELanguage2_3(path, isFile, isJSON)
+>>> l.language_match(s)
+True
 
 -----------------------------------------------------
 Test for _unbind(cls, boundname)


### PR DESCRIPTION
This is a draft PR for the WIP NVD JSON configuration support. It is not well tested as of now and is mainly here to gather early feedback.

---

This current feature implementation translate the JSON configuration into the old XML standard so that it gets processed by `CPELanguage2_3`.

This implementation is far from being the best way of dealing with this feature but it is the quickest I have found to support new JSON configuration as well as ensuring no breaking changes with existing codebase.

Closes: #42 