### PR TITLE
Updated _VALUE_PATTERN for CPE 2.2

### DIFF
--- a/cpe/comp/cpecomp2_2.py
+++ b/cpe/comp/cpecomp2_2.py
@@ -49,7 +49,7 @@ class CPEComponent2_2(CPEComponentSimple):
     ###############
 
     #: Pattern used to check the value of component
-    _VALUE_PATTERN = "^([\d\w\._\-~%]+)$"
+    _VALUE_PATTERN = r"^([\d\w\._\-~%\\/]+)$"
 
     #: Separator of components of CPE name with URI style
     SEPARATOR_COMP = ":"

--- a/tests/unit/test_cpe2_2.py
+++ b/tests/unit/test_cpe2_2.py
@@ -132,6 +132,9 @@ def test_getitem_3():
     # The CPE Name below shows an example for a virtual hardware
     # platform.
     'cpe:/h:emc:vmware_esx:2.5',
+
+    # The CPE name below shows a valid CPE that contains a '/' in the product
+    'cpe:/a:intel:proset\/wireless_wifi'
 ])
 def test_new_legal_cpe(s):
     """legal cpe"""


### PR DESCRIPTION
According to https://nvd.nist.gov/products/cpe/search, the following CPE is a valid CPE: `cpe:/a:intel:proset\/wireless_wifi` 

However, the current `_VALUE_PATTERN` in cpecomp2_2.py does not recognize it as valid:

```
>>> CPE("cpe:/a:intel:proset\/wireless_wifi").as_uri_2_3()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/chad/.pyenv/versions/service_tvdb_loader/lib/python3.10/site-packages/cpe/cpe.py", line 311, in __new__
    raise NotImplementedError(errmsg)
NotImplementedError: Version of CPE not implemented
```

With the changes in this PR, this CPE becomes recognized as valid:

```
>>> from cpe.comp.cpecomp2_2 import CPEComponent2_2
>>> from cpe import CPE
>>> import re
>>> CPEComponent2_2._value_rxc = re.compile(r"^([\d\w\._\-~%\\/]+)$")
>>> CPE("cpe:/a:intel:proset\/wireless_wifi").as_uri_2_3()
'cpe:/a:intel:proset%2fwireless_wifi'
```