### PR TITLE
Fix invalid/deprecated escape sequences

### DIFF
--- a/cpe/comp/cpecomp2_3_fs.py
+++ b/cpe/comp/cpecomp2_3_fs.py
@@ -47,8 +47,8 @@ class CPEComponent2_3_FS(CPEComponent2_3):
     ###############
 
     # Patterns used to check the value of component
-    _UNRESERVED = "\w|\.|\-"
-    _PUNC = "\!|\"|\;|\#|\$|\%|\&|\'|\(|\)|\+|\,|\/|\:|\<|\=|\>|\@|\[|\]|\^|\`|\{|\||\}|\~|\-"
+    _UNRESERVED = r"\w|\.|\-"
+    _PUNC = r"\!|\"|\;|\#|\$|\%|\&|\'|\(|\)|\+|\,|\/|\:|\<|\=|\>|\@|\[|\]|\^|\`|\{|\||\}|\~|\-"
 
     #: Separator of components of CPE name with URI style
     SEPARATOR_COMP = ":"
@@ -74,9 +74,9 @@ class CPEComponent2_3_FS(CPEComponent2_3):
     ###############
 
     # Compilation of regular expression associated with value of CPE part
-    _logical = "(\{0}|{1})".format(VALUE_ANY, VALUE_NA)
-    _quest = "\{0}".format(WILDCARD_ONE)
-    _asterisk = "\{0}".format(WILDCARD_MULTI)
+    _logical = r"(\{0}|{1})".format(VALUE_ANY, VALUE_NA)
+    _quest = r"\{0}".format(WILDCARD_ONE)
+    _asterisk = r"\{0}".format(WILDCARD_MULTI)
     _special = "{0}|{1}".format(_quest, _asterisk)
     _spec_chrs = "{0}+|{1}".format(_quest, _asterisk)
     _quoted = r"\\(\\" + "|{0}|{1})".format(_special, _PUNC)

--- a/cpe/comp/cpecomp2_3_wfn.py
+++ b/cpe/comp/cpecomp2_3_wfn.py
@@ -46,7 +46,7 @@ class CPEComponent2_3_WFN(CPEComponent2_3):
 
     # Patterns used to check the value of component
     _ESCAPE = r"\\"
-    _PUNC_NO_DASH = "\!|\"|\;|\#|\$|\%|\&|\'|\(|\)|\+|\,|\.|\/|\:|\<|\=|\>|\@|\[|\]|\^|\`|\{|\||\}|\~"
+    _PUNC_NO_DASH = r"\!|\"|\;|\#|\$|\%|\&|\'|\(|\)|\+|\,|\.|\/|\:|\<|\=|\>|\@|\[|\]|\^|\`|\{|\||\}|\~"
 
     #: Separator of components of CPE name with URI style
     SEPARATOR_COMP = ", "
@@ -74,8 +74,8 @@ class CPEComponent2_3_WFN(CPEComponent2_3):
     #  VARIABLES  #
     ###############
 
-    _spec1 = "\{0}".format(WILDCARD_ONE)
-    _spec2 = "\{0}".format(WILDCARD_MULTI)
+    _spec1 = r"\{0}".format(WILDCARD_ONE)
+    _spec2 = r"\{0}".format(WILDCARD_MULTI)
     _spec_chrs = "{0}+|{1}".format(_spec1, _spec2)
     _special = "{0}|{1}".format(_spec1, _spec2)
     _punc_w_dash = "{0}|-".format(_PUNC_NO_DASH)
@@ -83,8 +83,8 @@ class CPEComponent2_3_WFN(CPEComponent2_3):
                                          _PUNC_NO_DASH)
     _quoted2 = "{0}({1}|{2}|{3})".format(_ESCAPE, _ESCAPE,
                                          _special, _punc_w_dash)
-    _body1 = "\w|{0}".format(_quoted1)
-    _body2 = "\w|{0}".format(_quoted2)
+    _body1 = r"\w|{0}".format(_quoted1)
+    _body2 = r"\w|{0}".format(_quoted2)
     _body = "(({0})({1})*)|{2}({3})+".format(_body1, _body2, _body2, _body2)
     _avstring_pattern = "^((({0})|(({1})({2})*))({3})?)$".format(_body,
                                                                  _spec_chrs,

--- a/cpe/comp/cpecomp_anyvalue.py
+++ b/cpe/comp/cpecomp_anyvalue.py
@@ -38,7 +38,7 @@ class CPEComponentAnyValue(CPEComponentLogical):
 
     For example, in version 2.3 of CPE specification, an component "any value"
     is other attribute in CPE name
-    cpe:2.3:a:microsft:windows:xp:\*:\*:\*:\*:\*:\*:\*.
+    cpe:2.3:a:microsft:windows:xp:*:*:*:*:*:*:*.
     """
 
     ####################


### PR DESCRIPTION
There are a couple more invalid escape sequences. These are not meant to be Python string escape sequences, but literal backspace used for those regular expressions. Use the raw string prefix r"" for these strings.

These addresses warnings seen with Python 3.12:

```
/usr/local/lib/python3.12/site-packages/cpe/comp/cpecomp2_3_wfn.py:49: SyntaxWarning: invalid escape sequence '\!'
  _PUNC_NO_DASH = "\!|\"|\;|\#|\$|\%|\&|\'|\(|\)|\+|\,|\.|\/|\:|\<|\=|\>|\@|\[|\]|\^|\`|\{|\||\}|\~"
/usr/local/lib/python3.12/site-packages/cpe/comp/cpecomp2_3_wfn.py:77: SyntaxWarning: invalid escape sequence '\{'
  _spec1 = "\{0}".format(WILDCARD_ONE)
/usr/local/lib/python3.12/site-packages/cpe/comp/cpecomp2_3_wfn.py:78: SyntaxWarning: invalid escape sequence '\{'
  _spec2 = "\{0}".format(WILDCARD_MULTI)
/usr/local/lib/python3.12/site-packages/cpe/comp/cpecomp2_3_wfn.py:86: SyntaxWarning: invalid escape sequence '\w'
  _body1 = "\w|{0}".format(_quoted1)
/usr/local/lib/python3.12/site-packages/cpe/comp/cpecomp2_3_wfn.py:87: SyntaxWarning: invalid escape sequence '\w'
  _body2 = "\w|{0}".format(_quoted2)
/usr/local/lib/python3.12/site-packages/cpe/comp/cpecomp2_3_fs.py:50: SyntaxWarning: invalid escape sequence '\w'
  _UNRESERVED = "\w|\.|\-"
/usr/local/lib/python3.12/site-packages/cpe/comp/cpecomp2_3_fs.py:51: SyntaxWarning: invalid escape sequence '\!'
  _PUNC = "\!|\"|\;|\#|\$|\%|\&|\'|\(|\)|\+|\,|\/|\:|\<|\=|\>|\@|\[|\]|\^|\`|\{|\||\}|\~|\-"
/usr/local/lib/python3.12/site-packages/cpe/comp/cpecomp2_3_fs.py:77: SyntaxWarning: invalid escape sequence '\{'
  _logical = "(\{0}|{1})".format(VALUE_ANY, VALUE_NA)
/usr/local/lib/python3.12/site-packages/cpe/comp/cpecomp2_3_fs.py:78: SyntaxWarning: invalid escape sequence '\{'
  _quest = "\{0}".format(WILDCARD_ONE)
/usr/local/lib/python3.12/site-packages/cpe/comp/cpecomp2_3_fs.py:79: SyntaxWarning: invalid escape sequence '\{'
  _asterisk = "\{0}".format(WILDCARD_MULTI)
/usr/local/lib/python3.12/site-packages/cpe/comp/cpecomp_anyvalue.py:35: SyntaxWarning: invalid escape sequence '\*'
  """
```